### PR TITLE
Compact the beacon form factor, remove collisions and update the name

### DIFF
--- a/ir_beacon/models/ir_beacon/model.sdf
+++ b/ir_beacon/models/ir_beacon/model.sdf
@@ -4,24 +4,26 @@
 <model name="ir_beacon">
   <static>true</static>
   <pose>0.0 0.0 0.0 0 0 0</pose>
-  <link name="link">
-    <pose>0.0 0.0 0.025 0 0 0</pose>
+  <link name="led_mount">
+    <pose>0.0 0.0 0.0 0 0 0</pose>
+    <!-- Disabling collision to put it under the drone w/o needing to change the drone for a box collision.
     <collision name="collision">
       <geometry>
         <box>
-          <size>0.1 0.1 0.05</size>
+          <size>0.1 0.1 0.005</size>
         </box>
       </geometry>
-    </collision>
+    </collision> -->
     <visual name="visual">
+      <pose>0.0 0.0 0.0025 0 0 0</pose>
       <geometry>
         <box>
-          <size>0.1 0.1 0.05</size>
+          <size>0.1 0.1 0.005</size>
         </box>
       </geometry>
     </visual>
     <visual name="IR_LED_01">
-      <pose>0.025 0.025 0.025 0 0 0</pose>
+      <pose>0.025 0.025 0.005 0 0 0</pose>
       <geometry>
         <sphere>
           <radius>0.005 0.005 0.005</radius>
@@ -32,7 +34,7 @@
       </material>
     </visual>
     <visual name="IR_LED_02">
-      <pose>-0.025 0.025 0.025 0 0 0</pose>
+      <pose>-0.025 0.025 0.005 0 0 0</pose>
       <geometry>
         <sphere>
           <radius>0.005 0.005 0.005</radius>
@@ -43,7 +45,7 @@
       </material>
     </visual>
     <visual name="IR_LED_03">
-      <pose>-0.025 -0.025 0.025 0 0 0</pose>
+      <pose>-0.025 -0.025 0.005 0 0 0</pose>
       <geometry>
         <sphere>
           <radius>0.005 0.005 0.005</radius>
@@ -54,7 +56,7 @@
       </material>
     </visual>
     <visual name="IR_LED_04">
-      <pose>0.025 -0.025 0.025 0 0 0</pose>
+      <pose>0.025 -0.025 0.005 0 0 0</pose>
       <geometry>
         <sphere>
           <radius>0.005 0.005 0.005</radius>
@@ -68,4 +70,3 @@
 </model>
 
 </sdf>
-

--- a/ir_beacon/worlds/iris_beacon.world
+++ b/ir_beacon/worlds/iris_beacon.world
@@ -59,10 +59,10 @@
           <update_rate>30</update_rate>
           <visualize>false</visualize>
           <plugin name="ir" filename="libgazebo_irsensor_plugin.so">
-            <target>ir_beacon::link::IR_LED_01</target>
-            <target>ir_beacon::link::IR_LED_02</target>
-            <target>ir_beacon::link::IR_LED_03</target>
-            <target>ir_beacon::link::IR_LED_04</target>
+            <target>ir_beacon::led_mount::IR_LED_01</target>
+            <target>ir_beacon::led_mount::IR_LED_02</target>
+            <target>ir_beacon::led_mount::IR_LED_03</target>
+            <target>ir_beacon::led_mount::IR_LED_04</target>
           </plugin>
 
           <plugin name="camera_plugin" filename="libgazebo_ros_camera.so">


### PR DESCRIPTION
The new name is for disambiguation when using includes in models.