### PR TITLE
Add ability to toggle IR targets via ROS topic

### DIFF
--- a/ir_beacon/CMakeLists.txt
+++ b/ir_beacon/CMakeLists.txt
@@ -9,6 +9,8 @@ project(ir_beacon)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   gazebo_ros
+  roscpp
+  std_msgs
 )
 
 ## System dependencies are found with CMake's conventions
@@ -45,11 +47,12 @@ find_package(catkin REQUIRED COMPONENTS
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+ add_message_files(
+   DIRECTORY
+   msg
+   FILES
+   Targets.msg
+ )
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -66,10 +69,10 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
+ generate_messages(
+   DEPENDENCIES
+   std_msgs  # Or other packages containing msgs
+ )
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##

--- a/ir_beacon/CMakeLists.txt
+++ b/ir_beacon/CMakeLists.txt
@@ -10,7 +10,6 @@ project(ir_beacon)
 find_package(catkin REQUIRED COMPONENTS
   gazebo_ros
   roscpp
-  std_msgs
 )
 
 ## System dependencies are found with CMake's conventions

--- a/ir_beacon/CMakeLists.txt
+++ b/ir_beacon/CMakeLists.txt
@@ -70,8 +70,8 @@ find_package(catkin REQUIRED COMPONENTS
 
 ## Generate added messages and services with any dependencies listed here
  generate_messages(
-   DEPENDENCIES
-   std_msgs  # Or other packages containing msgs
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
  )
 
 ################################################

--- a/ir_beacon/msg/Targets.msg
+++ b/ir_beacon/msg/Targets.msg
@@ -1,0 +1,1 @@
+string[] targets

--- a/ir_beacon/package.xml
+++ b/ir_beacon/package.xml
@@ -16,4 +16,9 @@
     <!-- Other tools can request additional information be placed here -->
 
   </export>
+
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>genmsg</depend>
+
 </package>

--- a/ir_beacon/package.xml
+++ b/ir_beacon/package.xml
@@ -18,7 +18,6 @@
   </export>
 
   <depend>roscpp</depend>
-  <depend>std_msgs</depend>
   <depend>genmsg</depend>
 
 </package>

--- a/ir_beacon/plugins/CMakeLists.txt
+++ b/ir_beacon/plugins/CMakeLists.txt
@@ -8,9 +8,8 @@ set (SOURCES
 
 find_package(gazebo REQUIRED)
 
-
 include_directories(
-#  ${catkin_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
   ${GAZEBO_INCLUDE_DIRS}
 )
 
@@ -21,7 +20,7 @@ add_library(gazebo_irsensor_plugin SHARED
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 
-target_link_libraries(gazebo_irsensor_plugin ${GAZEBO_libraries})
+target_link_libraries(gazebo_irsensor_plugin ${GAZEBO_libraries} ${catkin_LIBRARIES})
 
 install(TARGETS gazebo_irsensor_plugin
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/plugins)

--- a/ir_beacon/plugins/IRSensorPlugin.hh
+++ b/ir_beacon/plugins/IRSensorPlugin.hh
@@ -26,6 +26,9 @@
 #include <gazebo/sensors/CameraSensor.hh>
 #include <gazebo/rendering/Camera.hh>
 
+#include <ros/ros.h>
+#include <ir_beacon/Targets.h>
+
 namespace gazebo
 {
   class IRMaterialHandler;
@@ -46,6 +49,11 @@ namespace gazebo
     // Documentation inherited
     public: virtual void Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf);
 
+    /// \brief Callback for new IR targets are specified
+    /// \param[in] _msg Targets message containing a string array field
+    /// named 'targets'
+    public: void TargetCallback(const ir_beacon::Targets::ConstPtr &_msg);
+
     /// \brief Pointer to parent sensor
     private: sensors::CameraSensorPtr parentSensor;
 
@@ -55,6 +63,12 @@ namespace gazebo
     /// \brief switcher the material of objects in camera view for simulating 
     /// IR camera
     private: IRMaterialHandlerPtr materialHandler;
+
+    /// \brief ROS node handle
+    private: ros::NodeHandle nh;
+
+    /// \brief ROS subscriber to IR target topic
+    private: ros::Subscriber sub;
   };
 }
 #endif


### PR DESCRIPTION
I decided to use ROS topic for toggling the IR targets instead of a ROS param server to keep things simple.

To test, launch the demo world as usual:

~~~
roslaunch ir_beacon ir_beacon.launch
~~~

this reads the 4 default targets from SDF.

you can then change the list of targets by publishing to the `/ir_targets` topic, e.g.

~~~
rostopic pub -1 /ir_targets ir_beacon/Targets "{targets:['ir_beacon::led_mount::IR_LED_01', 'ir_beacon::led_mount::IR_LED_04']}"
~~~

if you have `rqt image view` open, you should see that now there are only 2 IR targets being tracked instead of 4