### PR TITLE
Adding VehicleStatus.msg

### DIFF
--- a/proposed_aerial_msgs/CMakeLists.txt
+++ b/proposed_aerial_msgs/CMakeLists.txt
@@ -60,6 +60,7 @@ add_message_files(
   OdometryWithAcceleration.msg
   UpperTriangularCovariance.msg
   UpperTriangularCovariance3.msg
+  VehicleStatus.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/proposed_aerial_msgs/msg/VehicleStatus.msg
+++ b/proposed_aerial_msgs/msg/VehicleStatus.msg
@@ -1,0 +1,18 @@
+# This message represents vehicle information
+
+# HIL
+uint8 HIL_STATE_OFF = 0
+uint8 HIL_STATE_ON = 1
+
+uint8 VEHICLE_TYPE_UNKNOWN = 0
+uint8 VEHICLE_TYPE_ROTARY_WING = 1
+uint8 VEHICLE_TYPE_FIXED_WING = 2
+uint8 VEHICLE_TYPE_ROVER = 3
+uint8 VEHICLE_TYPE_VTOL = 4
+
+std_msgs/Header header
+
+uint8 system_type     # system type
+bool engine_failure   # Set to true if an engine failure is detected
+bool failsafe         # true if system is in failsafe state
+uint8 hil_state       # current hil state


### PR DESCRIPTION
This message is to include more relevant and generic information about the platform itself

 - system_type (plane, rover, drone, VTOL)
 - engine_failure 
 - failsafe
 - hil_state

what do you think @tfoote ? Which more fields do you think are generic enough to be included in this msg?