### PR TITLE
Remove the --home argument to run.

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -10,6 +10,6 @@ fi
 
 ARGS=("$@")
 
-rocker --x11 --nvidia --user --home --pulse  $IMG ${ARGS[@]}
+rocker --x11 --nvidia --user --pulse  $IMG ${ARGS[@]}
 
 


### PR DESCRIPTION
 * [x] Requires osrf/rocker#71 to be released in rocker 0.1.10
